### PR TITLE
fix a typo

### DIFF
--- a/en/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/en/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -15,7 +15,7 @@
    <void />
   </methodsynopsis>
   <para>
-   The application must close the zhandle and try to reconnect.
+   The application must close the handle and try to reconnect.
   </para>
  </refsect1>
 


### PR DESCRIPTION
fix Zookeeper::isRecoverable doc typo.